### PR TITLE
Better implementation that avoids Relay.Route completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ var NestedRootContainer = require('relay-nested-routes')(React, Relay);
 ReactDOM.render((
   <Router history={new BrowserHistory()}>
     <Route component={NestedRootContainer}>
-      <Route component={App} route={AppRoute}>
-        <Route path="/" component={Dashboard} route={DashboardRoute}/>
+      <Route component={App} queries={AppQueries}>
+        <Route path="/" component={Dashboard} queries={DashboardQueries}/>
       </Route>
     </Route>
   </Router>
 ), document.getElementById('react-root'));
 ```
 
-Define a `Relay.Route` that contains just the data that a particular `Relay.Container` needs and add it as a `route` prop to any container `<Route/>`s.
+Define root queries that contains just the queries that a particular `Relay.Container` needs and add it as a `queries` prop to any container `<Route/>`s.
 
-relay-nested-routes will automatically generate a component that includes all of your fragments, and a route that includes all of your root queries, and dispatch/render everything in one go.
+`relay-nested-routes` will automatically generate a component that includes all of your fragments, and a route that includes all of your root queries, and dispatch/render everything in one go.
 
 # Todo
 

--- a/src/NestedRenderer.js
+++ b/src/NestedRenderer.js
@@ -15,9 +15,10 @@ export default function generateNestedRenderer(React, components, fragments) {
     static getQueryNames() {}
 
     render() {
-      return components.reduceRight((children, generateComponent) => {
-        return generateComponent.call(this, { children: children });
-      }, null);
+      return components.reduceRight(
+        (children, generate) => generate.call(this, {children}),
+        null
+      );
     }
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,13 @@ export default function generateRootContainer(React, Relay) {
     }
 
     render() {
-      const { Component, route } = this.state;
-
+      const {Component, route} = this.state;
       return (
         <Relay.RootContainer
           {...this.props}
           Component={Component}
-          route={{ ...route, params: this.props.params }}/>
+          route={route}
+        />
       );
     }
   };


### PR DESCRIPTION
This is an iteration over relay-nested-routes that avoids Relay.Route by putting the queries directly on the react-router `Route`s. When adding a `name` and `queries` to react-router `Route`'s we already have two-thirds of a RelayQueryConfig. We only need to attach the `params` to these two fields, which this library does automatically.

Example: https://github.com/cpojer/relay-starter-kit/blob/nested-routes-example/js/app.js
Example with react-router only: https://github.com/cpojer/relay-starter-kit/blob/react-router-example/js/app.js

I'll double check with the core Relay team about the usage of internal APIs around fragment pointers.

I've also cleaned up the code-style to be more facebook-y, for which I hope not to receive a lot of hate :)

@devknoll do you have a test case with more nested routes? I'm only using the starter kit right now and I don't have any nested Relay Containers there, actually. ugh.