### PR TITLE
Don't need to explicitly cache containers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@ export default function generateRootContainer(React, Relay) {
     }
 
     componentWillReceiveProps(props) {
+      if (props.isTransitioning) {
+        return;
+      }
+
       this.setState(generateContainer(React, Relay, props));
     }
 


### PR DESCRIPTION
I might be misunderstanding what the cache was for, but this is sufficient to prevent odd behavior on route changes. I don't think it's necessary to cache e.g. the routes otherwise.