### PR TITLE
Make params work

### DIFF
--- a/src/defaultGetParams.js
+++ b/src/defaultGetParams.js
@@ -1,0 +1,3 @@
+export default function defaultGetParams({params, query}) {
+  return {...params, ...query};
+}

--- a/src/generateContainer.js
+++ b/src/generateContainer.js
@@ -1,3 +1,4 @@
+import defaultGetParams from './defaultGetParams';
 import generateNestedRenderer from './NestedRenderer';
 import invariant from 'invariant';
 
@@ -7,49 +8,87 @@ export default function generateContainer(React, Relay, newProps) {
   const queries = {};
   const fragments = {};
   const allRouteNames = [];
+  const params = {};
   let queryIdx = 0;
 
   const [, ...elems] = components.map((Component, index) => {
+    if (!Relay.isContainer(Component)) {
+      return props => <Component {...props}/>;
+    }
+
+    const componentName = Component.displayName || Component.name;
+
+    const currentNode = branch[index];
+    let { route } = currentNode;
+    const { routeClass, params: getParams = defaultGetParams} = currentNode;
+
+    // Not using XOR here allows better invariant error messages.
+    invariant(
+      route || routeClass,
+      `relay-nested-routes: Route with component \`${componentName}\` is `+
+      `missing a route or routeClass prop: ` +
+      `<Route component={${componentName}} route={...}/> or` +
+      `<Route component={${componentName}} routeClass={...}/> or`
+    );
+    invariant(
+      !(route && routeClass),
+      `relay-nested-routes: Route with component \`${componentName}\` ` +
+      `specifies both route and routeClass`
+    );
+
+    const routeParams = getParams({
+      params: newProps.params,
+      query: newProps.location.query
+    });
+    Object.keys(routeParams).forEach(paramKey => {
+      if (params[paramKey !== undefined]) {
+        invariant(
+          params[paramKey] === routeParams[paramKey],
+          `relay-nested-routes: Route with component \`${componentName}\`` +
+          ` has conflict on param \`${paramKey}\``
+        );
+      }
+
+      params[paramKey] = routeParams[paramKey];
+    });
+
+    // Explicitly constructing the route from the class allows us to re-use
+    // any invariants like required params on the route constructor.
+    if (routeClass) {
+      route = new routeClass(params);
+    }
+
+    const routeName = route.name;
+    allRouteNames.push(routeName);
+
     const fragmentResolvers = [];
 
-    if (Relay.isContainer(Component)) {
-      const { route } = branch[index];
-      invariant(
-        route,
-        `relay-nested-routes: Route with component ` +
-        `\`${Component.displayName}\` is missing a route prop: ` +
-        `<Route component={${Component.displayName}} route={...}/>`
-      );
-
-      const routeName = route.name;
-      allRouteNames.push(routeName);
-
-      Object.keys(route.queries).forEach(queryName => {
-        const newQueryName = `Nested_${routeName}_${queryName}_${++queryIdx}`;
-        fragments[newQueryName] = queries[newQueryName] = (_, ...args) => {
-          return route.queries[queryName](Component, ...args);
-        };
-        fragmentResolvers.push({
-          prop: queryName,
-          resolve: function getLocalProp() {
-            return this.props[newQueryName];
-          }
-        });
+    Object.keys(route.queries).forEach(queryName => {
+      const newQueryName = `Nested_${routeName}_${queryName}_${++queryIdx}`;
+      fragments[newQueryName] = queries[newQueryName] = (_, ...args) => {
+        return route.queries[queryName](Component, ...args);
+      };
+      fragmentResolvers.push({
+        prop: queryName,
+        resolve: function getLocalProp() {
+          return this.props[newQueryName];
+        }
       });
-    }
+    });
 
     return function ComponentGenerator(props) {
       fragmentResolvers.forEach(fragment => {
         props[fragment.prop] = fragment.resolve.call(this);
       });
 
-      return <Component {...props}/>;
+      return <Component {...props} {...routeParams}/>;
     };
   });
 
   const route = {
     name: ['Nested', ...allRouteNames].join('_'),
-    queries
+    queries,
+    params
   };
 
   return {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@ export default function generateRootContainer(React, Relay) {
     }
 
     componentWillReceiveProps(props) {
+      if (this.props.isTransitioning) {
+        return;
+      }
+
       this.setState(generateContainer(React, Relay, props));
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default function generateRootContainer(React, Relay) {
         <Relay.RootContainer
           {...this.props}
           Component={Component}
-          route={{ ...route, params: this.props.params }}/>
+          route={route}/>
       );
     }
   };


### PR DESCRIPTION
This untidily includes the changes from #3 - I can rip it out if you think #2 is incorrect.

Contra #2 this actually uses the `Relay.Route` constructor so that invariants for required parameters can be maintained.

IMO it might be nice to have something like a new `RelayRoute` class that extends `Router.Route` - the invariant checks around specifying a Relay route might be better done in `propTypes`.